### PR TITLE
Remove unused imports in Landing component

### DIFF
--- a/frontend/src/screens/Landing.tsx
+++ b/frontend/src/screens/Landing.tsx
@@ -1,4 +1,5 @@
-import { Bot, BookOpen, Eye, Globe, HelpCircle, MessageSquare, Search, Newspaper, Users, MoreHorizontal } from 'lucide-react'
+// import { Bot, BookOpen, Eye, Globe, HelpCircle, MessageSquare, Search, Newspaper, Users, MoreHorizontal } from 'lucide-react'
+import { Bot, BookOpen,MessageSquare,} from 'lucide-react'
 
 export const Landing = () => {
   return (


### PR DESCRIPTION
This pull request includes a small change to the `frontend/src/screens/Landing.tsx` file. The change comments out the import of several unused icons and keeps only the necessary ones.

* [`frontend/src/screens/Landing.tsx`](diffhunk://#diff-e7d3c9188d0f8eca8b2958ee6d006e3f318831f6b64cbdc44ab9f1683563789eL1-R2): Commented out the import of unnecessary icons and retained only `Bot`, `BookOpen`, and `MessageSquare` from `lucide-react`.