### PR TITLE
Refactor Game component to simplify state management by removing setC…

### DIFF
--- a/frontend/src/screens/Game.tsx
+++ b/frontend/src/screens/Game.tsx
@@ -11,7 +11,7 @@ export const GAME_OVER = "game_over";
 
 export const Game = () => {
     const socket = useSocket();
-    const [chess, setChess] = useState(new Chess());
+    const [chess] = useState(new Chess());
     const [board, setBoard] = useState(chess.board());
     const [started, setStarted] = useState(false);
 


### PR DESCRIPTION
This pull request includes a small change to the `frontend/src/screens/Game.tsx` file. The change removes an unused state setter function for the `chess` state variable.

* [`frontend/src/screens/Game.tsx`](diffhunk://#diff-266c0a22501f6d1143345e689407522a92ccf0da21a47b3ca17188d3b35385f8L14-R14): Removed the `setChess` state setter function from the `useState` hook for the `chess` state variable as it is not being used.